### PR TITLE
Ch8, optimize use of aer backend instance

### DIFF
--- a/7_grovers_search/qsharp/01_oracles/test_oracles.py
+++ b/7_grovers_search/qsharp/01_oracles/test_oracles.py
@@ -21,15 +21,15 @@ def test_mark_states(n, markedStates):
        f"GroversSearch.Test.FMarkStates(_, {markedStates}))")
 
 
-@pytest.mark.parametrize("n, marked_states", test_cases)
-def test_apply_phase_oracle(n, marked_states):
+@pytest.mark.parametrize("n, markedStates", test_cases)
+def test_apply_phase_oracle(n, markedStates):
   init(project_root='.')
   matrix = dump_operation(f"GroversSearch.ApplyPhaseOracle(_, GroversSearch.MarkStates(_, _, {markedStates}))", n)
 
   complete_coef = []
   for state in range(2 ** n):
     row = [0] * (2 ** n)
-    row[state] = -1 if state in marked_states else 1
+    row[state] = -1 if state in markedStates else 1
     complete_coef += [row]
 
   for actual, expected in zip(matrix, complete_coef):

--- a/7_grovers_search/qsharp/01_oracles/test_oracles.py
+++ b/7_grovers_search/qsharp/01_oracles/test_oracles.py
@@ -21,15 +21,15 @@ def test_mark_states(n, markedStates):
        f"GroversSearch.Test.FMarkStates(_, {markedStates}))")
 
 
-@pytest.mark.parametrize("n, markedStates", test_cases)
-def test_apply_phase_oracle(n, markedStates):
+@pytest.mark.parametrize("n, marked_states", test_cases)
+def test_apply_phase_oracle(n, marked_states):
   init(project_root='.')
   matrix = dump_operation(f"GroversSearch.ApplyPhaseOracle(_, GroversSearch.MarkStates(_, _, {markedStates}))", n)
 
   complete_coef = []
   for state in range(2 ** n):
     row = [0] * (2 ** n)
-    row[state] = -1 if state in markedStates else 1
+    row[state] = -1 if state in marked_states else 1
     complete_coef += [row]
 
   for actual, expected in zip(matrix, complete_coef):

--- a/8_n_queens/qiskit/02_bits/n_queens/run_n_queens.py
+++ b/8_n_queens/qiskit/02_bits/n_queens/run_n_queens.py
@@ -7,11 +7,11 @@ from qiskit_aer import Aer
 n_rows = 4
 
 print(f"Running for board size {n_rows}, mode = Bits")
+simulator = Aer.get_backend('aer_simulator')
 
 for n_iter in range(4, 10):
   n_runs = 100
   circ = grovers_search(n_rows, n_iter)
-  simulator = Aer.get_backend('aer_simulator')
   circ = transpile(circ, backend=simulator)
   start_time = time()
   res_map = simulator.run(circ, shots=n_runs).result().get_counts()

--- a/8_n_queens/qiskit/02_bits/n_queens/run_n_queens.py
+++ b/8_n_queens/qiskit/02_bits/n_queens/run_n_queens.py
@@ -8,11 +8,12 @@ n_rows = 4
 
 print(f"Running for board size {n_rows}, mode = Bits")
 simulator = Aer.get_backend('aer_simulator')
+n_runs = 100
 
 for n_iter in range(4, 10):
-  n_runs = 100
   circ = grovers_search(n_rows, n_iter)
   circ = transpile(circ, backend=simulator)
+
   start_time = time()
   res_map = simulator.run(circ, shots=n_runs).result().get_counts()
   end_time = time()

--- a/8_n_queens/qiskit/03_indices/n_queens/run_n_queens.py
+++ b/8_n_queens/qiskit/03_indices/n_queens/run_n_queens.py
@@ -7,12 +7,13 @@ from qiskit_aer import Aer
 n_rows = 4
 
 print(f"Running for board size {n_rows}, mode = Indices")
+simulator = Aer.get_backend('aer_simulator')
+n_runs = 100
 
 for n_iter in range(4, 10):
-  n_runs = 100
   circ = grovers_search(n_rows, n_iter)
-  simulator = Aer.get_backend('aer_simulator')
   circ = transpile(circ, backend=simulator)
+
   start_time = time()
   res_map = simulator.run(circ, shots=n_runs).result().get_counts()
   end_time = time()


### PR DESCRIPTION
Contains two updates:
- Fixes the `markedStates` naming in the Ch 7 oracle Q# test
- Moves the `aer_backend` instance outside for loops for speed